### PR TITLE
CVE-2021-25749: runAsNonRoot logic bypass for Windows containers

### DIFF
--- a/2021/25xxx/CVE-2021-25749.json
+++ b/2021/25xxx/CVE-2021-25749.json
@@ -2,17 +2,112 @@
     "data_type": "CVE",
     "data_format": "MITRE",
     "data_version": "4.0",
+    "generator": {
+      "engine": "Vulnogram 0.0.9"
+    },
     "CVE_data_meta": {
-        "ID": "CVE-2021-25749",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+      "ID": "CVE-2021-25749",
+      "ASSIGNER": "security@kubernetes.io",
+      "DATE_PUBLIC": "2022-09-15T21:37:00.000Z",
+      "TITLE": "runAsNonRoot logic bypass for Windows containers",
+      "STATE": "PUBLIC"
+    },
+    "source": {
+        "defect": [
+            "https://github.com/kubernetes/kubernetes/issues/112192"
+        ],
+        "discovery": "EXTERNAL"
+    },
+    "affects": {
+      "vendor": {
+        "vendor_data": [
+          {
+            "vendor_name": "Kubernetes",
+            "product": {
+              "product_data": [
+                {
+                  "product_name": "Kubernetes",
+                  "version": {
+                    "version_data": [
+                      {
+                        "version_name": "kubelet v1.22.0 - v1.22.13",
+                        "version_affected": "<",
+                        "version_value": "v1.22.14"
+                      },
+                      {
+                        "version_name": "kubelet v1.23.0 - v1.23.10",
+                        "version_affected": "<",
+                        "version_value": "v1.23.11"
+                      },
+                      {
+                        "version_name": "kubelet v1.24.0 - v1.24.4",
+                        "version_affected": "<",
+                        "version_value": "v1.24.5"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": [
+            {
+              "lang": "eng",
+              "value": "CWE-284 Improper Access Control"
+            }
+          ]
+        }
+      ]
     },
     "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
-    }
-}
+      "description_data": [
+        {
+          "lang": "eng",
+          "value": "Windows workloads can run as ContainerAdministrator even when those workloads set the runAsNonRoot option to true."
+        }
+      ]
+    },
+    "references": {
+      "reference_data": [
+        {
+          "refsource": "MLIST",
+          "url": "https://groups.google.com/g/kubernetes-security-announce/c/qqTZgulISzA"
+        }
+      ]
+    },
+    "configuration": [],
+    "impact": {
+      "cvss": {
+        "version": "3.1",
+        "attackVector": "LOCAL",
+        "attackComplexity": "LOW",
+        "privilegesRequired": "LOW",
+        "userInteraction": "NONE",
+        "scope": "UNCHANGED",
+        "confidentialityImpact": "HIGH",
+        "integrityImpact": "HIGH",
+        "availabilityImpact": "HIGH",
+        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "baseScore": 7.8,
+        "baseSeverity": "HIGH"
+      }
+    },
+    "solution": [
+      {
+        "lang": "eng",
+        "value": "To mitigate these vulnerabilities, upgrade Kubernetes: https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster"
+      }
+    ],
+    "credit": [
+      {
+        "lang": "eng",
+        "value": "Mark Rosetti (@marosset) of Microsoft"
+      }
+    ]
+  }


### PR DESCRIPTION
Populating CVE details for CVE-2021-25749